### PR TITLE
Release 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 1.0.4
+* Fix: Position & Visibility plugin options escaped twice.
+* Update position default to bottom.
+* Update unit tests.
+* Tested up to WP 6.8.2.
+
 # 1.0.3
 * Safely escape HTML output.
 * Tested up to WP 6.8.2

--- a/display-site-notification-bar.php
+++ b/display-site-notification-bar.php
@@ -3,7 +3,7 @@
  * Plugin Name: Display Site Notification Bar
  * Plugin URI:  https://github.com/badasswp/display-site-notification-bar
  * Description: Display a notice bar on your WP home page.
- * Version:     1.0.3
+ * Version:     1.0.4
  * Author:      badasswp
  * Author URI:  https://github.com/badasswp
  * License:     GPL v2 or later

--- a/inc/Services/Admin.php
+++ b/inc/Services/Admin.php
@@ -338,7 +338,7 @@ class Admin extends Service implements Kernel {
 	public function position_cb(): void {
 		$positions = '';
 
-		foreach ( [ 'top', 'bottom' ] as $position ) {
+		foreach ( [ 'bottom', 'top' ] as $position ) {
 			$selected = '';
 
 			if ( ( $this->options[ self::NOTICE_POSITION ] ?? '' ) === $position ) {
@@ -361,7 +361,15 @@ class Admin extends Service implements Kernel {
 			esc_attr( self::PLUGIN_OPTION ),
 			esc_attr( self::NOTICE_POSITION ),
 			esc_attr( $this->options[ self::NOTICE_POSITION ] ?? '' ),
-			esc_html( $positions )
+			wp_kses(
+				$positions,
+				[
+					'option' => [
+						'value'    => [],
+						'selected' => [],
+					],
+				]
+			)
 		);
 	}
 
@@ -398,7 +406,15 @@ class Admin extends Service implements Kernel {
 			esc_attr( self::PLUGIN_OPTION ),
 			esc_attr( self::NOTICE_VISIBILITY ),
 			esc_attr( $this->options[ self::NOTICE_VISIBILITY ] ?? '' ),
-			esc_html( $pages )
+			wp_kses(
+				$pages,
+				[
+					'option' => [
+						'value'    => [],
+						'selected' => [],
+					],
+				]
+			)
 		);
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "display-site-notification-bar",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"description": "Display a notice bar on your WP home page.",
 	"author": "badasswp",
 	"license": "GPL-3.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: badasswp
 Tags: site, notice, bar, home, page
 Requires at least: 4.0
 Tested up to: 6.8
-Stable tag: 1.0.3
+Stable tag: 1.0.4
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -57,6 +57,12 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 == Changelog ==
 
+= 1.0.4 =
+* Fix: Position & Visibility plugin options escaped twice.
+* Update position default to bottom.
+* Update unit tests.
+* Tested up to WP 6.8.2.
+
 = 1.0.3 =
 * Safely escape HTML output.
 * Tested up to WP 6.8.2


### PR DESCRIPTION
This release contains the following fixes:

- Fix: Position & Visibility plugin options escaped twice.
- Update position default to `bottom`.
- Update unit tests.
- Tested up to WP 6.8.2.