### PR TITLE
Feat:Add more plugins options page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.0
+* Feat: Add `More Plugins` options page.
+
 ## 1.0.5
 * Specify `wordpress-plugin` as Composer package type.
 * Tested up to WP 6.9.

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
       "email": "badasswpdev@gmail.com"
     }
   ],
+  "require": {
+    "badasswp/pluginate": "^1.0"
+  },
   "require-dev": {
     "phpunit/phpunit": "^9.6",
     "mockery/mockery": "^1.6",

--- a/inc/Services/Admin.php
+++ b/inc/Services/Admin.php
@@ -13,7 +13,27 @@ namespace DisplaySiteNotificationBar\Services;
 use DisplaySiteNotificationBar\Abstracts\Service;
 use DisplaySiteNotificationBar\Interfaces\Kernel;
 
+use Pluginate\Admin as Pluginate;
+
 class Admin extends Service implements Kernel {
+	/**
+	 * Pluginate instance.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @var Pluginate
+	 */
+	public Pluginate $pluginate;
+
+	/**
+	 * Admin constructor.
+	 *
+	 * @since 1.2.0
+	 */
+	public function __construct() {
+		$this->pluginate = new Pluginate( 'display-site-notification-bar' );
+	}
+
 	/**
 	 * Plugin Options.
 	 *
@@ -94,6 +114,7 @@ class Admin extends Service implements Kernel {
 	public function register(): void {
 		add_action( 'admin_menu', [ $this, 'register_options_page' ] );
 		add_action( 'admin_init', [ $this, 'register_options_init' ] );
+		add_action( 'admin_init', [ $this->pluginate, 'init' ] );
 	}
 
 	/**
@@ -112,6 +133,15 @@ class Admin extends Service implements Kernel {
 			[ $this, 'register_options_cb' ],
 			'dashicons-align-center',
 			100
+		);
+
+		add_submenu_page(
+			self::PLUGIN_SLUG,
+			__( 'More Plugins', 'ping-me-on-slack' ),
+			__( 'More Plugins', 'ping-me-on-slack' ),
+			'manage_options',
+			sprintf( '%s-more-plugins', self::PLUGIN_SLUG ),
+			[ $this, 'register_more_plugins' ]
 		);
 	}
 
@@ -137,6 +167,35 @@ class Admin extends Service implements Kernel {
 			</form>
 		</div>
 		<?php
+	}
+
+	/**
+	 * Register More Plugins.
+	 *
+	 * This controls the display of the
+	 * "More Plugins" submenu page.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return void
+	 */
+	public function register_more_plugins(): void {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		vprintf(
+			'<section class="wrap">
+				<h1>%s</h1>
+				<p>%s</p>
+				%s
+			</section>',
+			array_map(
+				'__',
+				[
+					'More Plugins',
+					'Check out some other amazing plugin of ours...',
+					$this->pluginate->get_more_plugins(),
+				]
+			)
+		);
 	}
 
 	/**

--- a/tests/Services/AdminTest.php
+++ b/tests/Services/AdminTest.php
@@ -21,6 +21,7 @@ use DisplaySiteNotificationBar\Services\Admin;
  * @covers \DisplaySiteNotificationBar\Services\Admin::visibility_cb
  * @covers \DisplaySiteNotificationBar\Services\Admin::sanitize_options
  * @covers \DisplaySiteNotificationBar\Services\Admin::get_settings
+ * @covers \DisplaySiteNotificationBar\Services\Admin::__construct
  */
 class AdminTest extends TestCase {
 	public function setUp(): void {
@@ -92,6 +93,7 @@ class AdminTest extends TestCase {
 
 		\WP_Mock::expectActionAdded( 'admin_menu', [ $admin, 'register_options_page' ] );
 		\WP_Mock::expectActionAdded( 'admin_init', [ $admin, 'register_options_init' ] );
+		\WP_Mock::expectActionAdded( 'admin_init', [ $admin->pluginate, 'init' ] );
 
 		$register = $admin->register();
 
@@ -111,6 +113,21 @@ class AdminTest extends TestCase {
 				[ $admin, 'register_options_cb' ],
 				'dashicons-align-center',
 				100
+			)
+			->andReturn( null );
+
+		\WP_Mock::userFunction( '__' )
+			->andReturnUsing( fn( $text, $domain ) => $text );
+
+		\WP_Mock::userFunction( 'add_submenu_page' )
+			->once()
+			->with(
+				'display-site-notification-bar',
+				'More Plugins',
+				'More Plugins',
+				'manage_options',
+				'display-site-notification-bar-more-plugins',
+				[ $admin, 'register_more_plugins' ]
 			)
 			->andReturn( null );
 


### PR DESCRIPTION
This PR resolves [WP-243](https://appworld.atlassian.net/browse/WP-243)

## Description / Background Context

This PR introduces a new More Plugins options page via the Pluginate repo.

## Testing Instructions

- Pull PR to local.
- Run `composer update` to pull in the `Pluginate` package.
- Proceed to the **More Plugins** page under the **Display Site Notification Bar** menu.
- Observe that everything still works correctly as expected and you can install and activate a plugin from same.

## Screenshots / Screencast

<img width="894" height="409" alt="Screenshot 2026-06-11 174318" src="https://github.com/user-attachments/assets/2ecd4ad7-85dc-4002-ba4c-ab9b247f0c3e" />


---

<img width="953" height="440" alt="Screenshot 2026-06-11 174717" src="https://github.com/user-attachments/assets/04fb05ef-ca2c-443c-b1ea-9ed4eb2139c6" />
